### PR TITLE
Expose "Compare" requests

### DIFF
--- a/ldap.go
+++ b/ldap.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/nmcclain/asn1-ber"
+	ber "github.com/nmcclain/asn1-ber"
 )
 
 // LDAP Application Codes
@@ -175,12 +175,12 @@ type ModifyDNRequest struct {
 	newSuperior  string
 }
 type AttributeValueAssertion struct {
-	attributeDesc  string
-	assertionValue string
+	AttributeDesc  string
+	AssertionValue string
 }
 type CompareRequest struct {
-	dn  string
-	ava []AttributeValueAssertion
+	DN  string
+	AVA []AttributeValueAssertion
 }
 type ExtendedRequest struct {
 	requestName  string

--- a/server_compare_test.go
+++ b/server_compare_test.go
@@ -1,0 +1,54 @@
+package ldap
+
+import (
+	"net"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+type compareKnownValues struct{}
+
+func (compareKnownValues) Compare(boundDN string, req CompareRequest, conn net.Conn) (LDAPResultCode, error) {
+	if req.dn != "cn=myUser,dc=example,dc=com" {
+		// unknown dn
+		return LDAPResultCompareFalse, nil
+	}
+
+	for _, ava := range req.ava {
+		if ava.attributeDesc != "myAttribute" || ava.assertionValue != "myValue" {
+			// unheld assertion
+			return LDAPResultCompareFalse, nil
+		}
+	}
+
+	return LDAPResultCompareTrue, nil
+}
+
+func TestCompareTrue(t *testing.T) {
+	s := NewServer()
+	s.BindFunc("", bindAnonOK{})
+	s.CompareFunc("", compareKnownValues{})
+
+	LaunchServerForTest(t, s, func() {
+		cmd := exec.Command("ldapcompare", "-v", "-H", ldapURL, "-x", "cn=myUser,dc=example,dc=com", "myAttribute:myValue")
+		out, _ := cmd.CombinedOutput()
+		if !strings.Contains(string(out), "Compare Result: Compare True") {
+			t.Errorf("ldapcompare failed: %v", string(out))
+		}
+	})
+}
+
+func TestCompareFalse(t *testing.T) {
+	s := NewServer()
+	s.BindFunc("", bindAnonOK{})
+	s.CompareFunc("", compareKnownValues{})
+
+	LaunchServerForTest(t, s, func() {
+		cmd := exec.Command("ldapcompare", "-v", "-H", ldapURL, "-x", "cn=myUser,dc=example,dc=com", "myAttribute:wrongValue")
+		out, _ := cmd.CombinedOutput()
+		if !strings.Contains(string(out), "Compare Result: Compare False") {
+			t.Errorf("ldapcompare failed: %v", string(out))
+		}
+	})
+}

--- a/server_compare_test.go
+++ b/server_compare_test.go
@@ -10,13 +10,13 @@ import (
 type compareKnownValues struct{}
 
 func (compareKnownValues) Compare(boundDN string, req CompareRequest, conn net.Conn) (LDAPResultCode, error) {
-	if req.dn != "cn=myUser,dc=example,dc=com" {
+	if req.DN != "cn=myUser,dc=example,dc=com" {
 		// unknown dn
 		return LDAPResultCompareFalse, nil
 	}
 
-	for _, ava := range req.ava {
-		if ava.attributeDesc != "myAttribute" || ava.assertionValue != "myValue" {
+	for _, ava := range req.AVA {
+		if ava.AttributeDesc != "myAttribute" || ava.AssertionValue != "myValue" {
 			// unheld assertion
 			return LDAPResultCompareFalse, nil
 		}

--- a/server_modify.go
+++ b/server_modify.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/nmcclain/asn1-ber"
+	ber "github.com/nmcclain/asn1-ber"
 )
 
 func HandleAddRequest(req *ber.Packet, boundDN string, fns map[string]Adder, conn net.Conn) (resultCode LDAPResultCode) {
@@ -131,7 +131,7 @@ func HandleCompareRequest(req *ber.Packet, boundDN string, fns map[string]Compar
 	}
 	var ok bool
 	compReq := CompareRequest{}
-	compReq.dn, ok = req.Children[0].Value.(string)
+	compReq.DN, ok = req.Children[0].Value.(string)
 	if !ok {
 		return LDAPResultProtocolError
 	}
@@ -147,7 +147,7 @@ func HandleCompareRequest(req *ber.Packet, boundDN string, fns map[string]Compar
 	if !ok {
 		return LDAPResultProtocolError
 	}
-	compReq.ava = []AttributeValueAssertion{{attr, val}}
+	compReq.AVA = []AttributeValueAssertion{{attr, val}}
 	fnNames := []string{}
 	for k := range fns {
 		fnNames = append(fnNames, k)


### PR DESCRIPTION
The compare message's fields are now public, so downstream projects (Authentik) can respond to the compare message.

Part of https://github.com/goauthentik/authentik/issues/7522